### PR TITLE
Fix CMYK output on black

### DIFF
--- a/src/events/Events.cpp
+++ b/src/events/Events.cpp
@@ -151,7 +151,7 @@ void Events::handlePointerButton(void* data, struct wl_pointer* wl_pointer, uint
             // http://www.codeproject.com/KB/applications/xcmyk.aspx
 
             float r = 1 - COL.r / 255.0f, g = 1 - COL.g / 255.0f, b = 1 - COL.b / 255.0f;
-            float k = fmin3(r, g, b), K = 1 - k;
+            float k = fmin3(r, g, b), K = (k == 1) ? 1 : 1 - k;
             float c = (r - k) / K, m = (g - k) / K, y = (b - k) / K;
 
             c = std::round(c * 100);


### PR DESCRIPTION
### Reproduce:

* Open <https://duckduckgo.com/?q=%23000000">
* Launch `hyprpicker` with the `cmyk` format
```bash
hyprpicker --no-fancy --format cmyk 
```
* Click in the black circle
* Observe:
```
-nan% -nan% -nan% 0%
```

### Fix:

The current implementation does not handle the case where K = 0, which causes a divide by zero error when computing `c`, `m`, `y` which are of the form `[expr] / K`.

In this case, setting `K = 1` is a correct way to handle this edge case.
